### PR TITLE
fix: add option restart:always for docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - $HOME:$HOME:ro
     environment:
       SSH_AUTH_SOCK: /ssh/auth/sock
+    restart: always
 
 volumes:
   ssh:


### PR DESCRIPTION
ホストの再起動をするたびにExit: 255にならないように `restart: always` オプションを追加しました